### PR TITLE
Add missing deps and versions as needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ python = "^3.6"
 torch = "*"
 einops = "*"
 efficientnet_pytorch = "*"
-zetascale = "*"
+zetascale = "0.7.5"
 torchvision = "*"
-
+classifier_free_guidance_pytorch = "*"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Downgrade zetascale to 0.7.5 and add the `classifier_free_guidance_pytorch` dependency.
Issue: #8 
```
(rtx2) sebastianperalta@Sebastians-MacBook-Pro RT-X % pip install -e .
(rtx2) sebastianperalta@Sebastians-MacBook-Pro RT-X % python rtx2_example.py                                 

_____________________________________
\____    /\_   _____/\__    ___/  _    /     /  |    __)_   |    | /  /_\   /     /_  |        \  |    |/    |    /_______ \/_______  /  |____|\____|__  /
        \/        \/                 \/

(tensor([[[-0.1231,  1.0475, -1.4121,  ...,  0.7327,  0.2676, -0.9917],
         [-0.1652,  0.6748, -1.2642,  ...,  0.4205,  0.0133, -1.1175],
         [-0.2414,  0.5565, -1.6500,  ...,  0.6415, -0.2231, -1.2765],
         ...,
         [-0.5193,  0.0055, -1.1972,  ...,  0.2909,  0.5708, -0.1188],
         [-0.3632, -0.3819, -1.0702,  ...,  0.2849,  0.6384, -0.2764],
         [-0.7265, -0.1909, -1.0735,  ...,  0.0214,  0.4495, -0.3537]]],
       grad_fn=<ViewBackward0>), tensor(10.0672, grad_fn=<NllLoss2DBackward0>))
```